### PR TITLE
Handle pagination for ListInterview & ListResult

### DIFF
--- a/app/api/interviews/route.ts
+++ b/app/api/interviews/route.ts
@@ -4,8 +4,8 @@ import { NextResponse } from "next/server";
 export async function GET(request: Request) {
     try {
         const res = await getInterviews(request);
-        const { interviews } = res;
-        return NextResponse.json({ interviews });
+        const { interviews, resultsPerPage, filteredCount } = res;
+        return NextResponse.json({ interviews, resultsPerPage, filteredCount }, { status: 200 });
     } catch (error: any) {
         return NextResponse.json(
             { error: error.message || "Not authenticated" },

--- a/app/app/results/page.tsx
+++ b/app/app/results/page.tsx
@@ -4,12 +4,14 @@ import { getAuthHeader } from '@/helpers/auth';
 import ListResults from '@/components/result/ListResults';
 
 
-async function getInterviews() {
+async function getInterviews(searchParams: string) {
     try {
+        const urlParams = new URLSearchParams(searchParams);
+        const queryStr = urlParams.toString();
         const nextCookies = await cookies();
         const authHeader = getAuthHeader(nextCookies);
 
-        const res = await fetch(`${process.env?.API_URL}/api/interviews`, {
+        const res = await fetch(`${process.env?.API_URL}/api/interviews?${queryStr}`, {
             headers: authHeader.headers,
             method: 'GET',
         });
@@ -26,8 +28,9 @@ async function getInterviews() {
     }
 }
 
-const ResultsPage = async () => {
-    const data = await getInterviews();
+const ResultsPage = async ({ searchParams }: { searchParams: string }) => {
+    const searchParamsValue = await searchParams;
+    const data = await getInterviews(searchParamsValue);
 
     return (
         <ListResults data={data} />

--- a/backend/utils/apiFilters.ts
+++ b/backend/utils/apiFilters.ts
@@ -14,6 +14,15 @@ class APIFilters {
         this.query = this.query.find(queryCopy);
         return this;
     }
+
+    pagination(resultsPerPage: number) {
+        const currentPage = Number(this.queryStr.page) || 1;
+        const skip = resultsPerPage * (currentPage - 1);
+
+        this.query = this.query.limit(resultsPerPage).skip(skip);
+
+        return this;
+    }
 }
 
 export default APIFilters;

--- a/components/interview/ListInterviews.tsx
+++ b/components/interview/ListInterviews.tsx
@@ -22,6 +22,7 @@ import { deleteInterview } from "@/actions/interview.action";
 import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
 import { calculateAverageScore } from "@/helpers/interview";
+import CustomPagination from "../layout/pagination/CustomPagination";
 
 export const columns = [
   { name: "INTERVIEW", uid: "interview" },
@@ -33,11 +34,13 @@ export const columns = [
 type ListInterviewProps = {
   data: {
     interviews: IInterview[];
+    resultsPerPage: number;
+    filteredCount: number;
   };
 };
 
 export default function ListInterviews({ data }: ListInterviewProps) {
-  const { interviews } = data;
+  const { interviews, resultsPerPage, filteredCount } = data;
 
   const router = useRouter();
 
@@ -56,7 +59,7 @@ export default function ListInterviews({ data }: ListInterviewProps) {
 
   let queryParams;
 
-  const handleEstatusChange = (status: string) => {
+  const handleStatusChange = (status: string) => {
     queryParams = new URLSearchParams(window.location.search);
     if(queryParams.has("status") && status === "all") {
       queryParams.delete("status");
@@ -154,12 +157,12 @@ export default function ListInterviews({ data }: ListInterviewProps) {
     <div className="my-4">
       <div className="flex items-center justify-end mb-4">
         <Select size="sm" className="max-w-xs" label="Select a status"
-          onChange={(e) => handleEstatusChange(e.target.value)}
+          onChange={(e) => handleStatusChange(e.target.value)}
         >
           <SelectItem key={"all"}>All</SelectItem>
           <SelectItem key={"pending"}>Pending</SelectItem>
           <SelectItem key={"completed"}>Completed</SelectItem>
-      </Select>
+        </Select>
       </div>
       <Table aria-label="Interivews table">
         <TableHeader columns={columns}>
@@ -182,6 +185,10 @@ export default function ListInterviews({ data }: ListInterviewProps) {
           )}
         </TableBody>
       </Table>
+
+      <div className="flex justify-center items-center mt-10">
+        <CustomPagination resPerPage={resultsPerPage} filteredCount={filteredCount} />
+      </div>
     </div>
   );
 }

--- a/components/layout/pagination/CustomPagination.tsx
+++ b/components/layout/pagination/CustomPagination.tsx
@@ -1,0 +1,36 @@
+import { getTotalPages } from '@/helpers/helpers';
+import { Pagination } from '@heroui/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { use } from 'react'
+
+interface Props {
+    resPerPage: number;
+    filteredCount: number;
+}
+
+const CustomPagination = ({ resPerPage, filteredCount }: Props) => {
+    const router = useRouter();
+
+    const totalPages = getTotalPages(filteredCount, resPerPage);
+    const searchParams = useSearchParams();
+    let page = searchParams.get('page') || 1;
+    page = Number(page);
+
+    const handlePageChange = (newPage: number) => {
+        const params = new URLSearchParams(searchParams.toString()); 
+        params.set('page', newPage.toString());
+        router.push(`?${params.toString()}`);
+    };
+
+    return (
+        <div className="flex justify-center items-center mt-10">
+            <Pagination
+                isCompact showControls showShadow initialPage={1} 
+                total={totalPages} page={page}
+                onChange={handlePageChange}
+             />
+        </div>
+    )
+}
+
+export default CustomPagination;

--- a/components/result/ListResults.tsx
+++ b/components/result/ListResults.tsx
@@ -13,15 +13,20 @@ import {
   Tooltip,
   Button,
   Link,
+  Select,
+  SelectItem,
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
 import { Key } from "@react-types/shared";
 import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
+import CustomPagination from '../layout/pagination/CustomPagination';
 
 type Props = {
     data: {
-        interviews: IInterview[]
+        interviews: IInterview[],
+        resultsPerPage: number,
+        filteredCount: number,
     }
 }
 
@@ -33,7 +38,24 @@ export const columns = [
 ]
 
 const ListResults = ({ data }: Props) => {
-    const { interviews } = data;
+    const { interviews, resultsPerPage, filteredCount } = data;
+    console.log("ListResults", interviews);
+    const router = useRouter();
+
+    let queryParams;
+
+    const handleStatusChange = (status: string) => {
+      queryParams = new URLSearchParams(window.location.search);
+      if(queryParams.has("status") && status === "all") {
+        queryParams.delete("status");
+      } else if(queryParams.has("status")) {
+        queryParams.set("status", status);
+      } else {
+        queryParams.append("status", status);
+      }
+      const path = `${window.location.pathname}?${queryParams.toString()}`;
+      router.push(path);
+    };
 
     const renderCell = React.useCallback(
         (interview: IInterview, columnKey: Key) => {
@@ -93,6 +115,15 @@ const ListResults = ({ data }: Props) => {
 
     return (
     <div className="my-4">
+      <div className="flex items-center justify-end mb-4">
+        <Select size="sm" className="max-w-xs" label="Select a status"
+          onChange={(e) => handleStatusChange(e.target.value)}
+        >
+          <SelectItem key={"all"}>All</SelectItem>
+          <SelectItem key={"pending"}>Pending</SelectItem>
+          <SelectItem key={"completed"}>Completed</SelectItem>
+        </Select>
+      </div>
       <Table aria-label="Interivews table">
         <TableHeader columns={columns}>
           {(column) => (
@@ -114,6 +145,10 @@ const ListResults = ({ data }: Props) => {
           )}
         </TableBody>
       </Table>
+
+      <div className="flex justify-center items-center mt-10">
+        <CustomPagination resPerPage={resultsPerPage} filteredCount={filteredCount} />
+      </div>
     </div>
   );
 }

--- a/helpers/helpers.ts
+++ b/helpers/helpers.ts
@@ -23,8 +23,8 @@ export const formatTime= (seconds: number) => {
     return `${minutes?.toString().padStart(2, "0")}:${remainingSeconds?.toString().padStart(2, "0")}`
 }
 
-export const getTotalPages = (totalQuestions: number, questionsPerPage: number) => {
-    return Math.ceil(totalQuestions / questionsPerPage);
+export const getTotalPages = (totalItems: number, itemsPerPage: number) => {
+    return Math.ceil(totalItems / itemsPerPage);
 }
 
 export const paginate = <T>(


### PR DESCRIPTION
- add pagination in APIFilters
- return `resultsPerPage`, `filteredCount` in interview.controller & also GET method in api/interview/route.ts 
- Add `CustomPagination` component in `ListInterview` & `ListResult`

#### pagination (page=1)
<img width="631" alt="interview_pagination" src="https://github.com/user-attachments/assets/c90707b7-8c05-4fb2-81ad-b0847b4ffe54" />

#### pagination (page=2)
<img width="629" alt="interview_pagination2" src="https://github.com/user-attachments/assets/410b69c9-5b2b-40a9-a128-da321966a7e5" />

#### filter & pagination 
<img width="633" alt="interview_filtered_pagination" src="https://github.com/user-attachments/assets/9c9a9a12-45d0-4aad-a473-bd725f0bfd89" />
