### PR TITLE
fix build error

### DIFF
--- a/app/api/interviews/[id]/route.ts
+++ b/app/api/interviews/[id]/route.ts
@@ -1,7 +1,10 @@
 import { getInterviewById } from "@/backend/controllers/interview.controller";
 import { NextResponse } from "next/server";
 
-export async function GET(request: Request, { params }: { params: { id: string }}) {
+export async function GET(
+    request: Request, 
+    { params }: { params: Promise<{ id: string }> }
+) {
 
     try {
         const {id} = await params;

--- a/app/app/interviews/conduct/[id]/page.tsx
+++ b/app/app/interviews/conduct/[id]/page.tsx
@@ -26,7 +26,7 @@ async function getInterview(id: string) {
 }
 
 
-const InterviewConductPage = async ({params}: { params: { id: string }}) => {
+const InterviewConductPage = async ({params}: { params: Promise<{ id: string }> }) => {
     const {id} = await params;
     const data = await getInterview(id);
 

--- a/app/app/interviews/page.tsx
+++ b/app/app/interviews/page.tsx
@@ -28,7 +28,7 @@ async function getInterviews(searchParams: string) {
     }
 }
 
-const InterviewPage = async ({ searchParams }: { searchParams: string }) => {
+const InterviewPage = async ({ searchParams }: { searchParams: Promise<string> }) => {
     const searchParamsValue = await searchParams;
     const data = await getInterviews(searchParamsValue);
 

--- a/app/app/results/[id]/page.tsx
+++ b/app/app/results/[id]/page.tsx
@@ -27,7 +27,7 @@ async function getInterview(id: string) {
 }
 
 
-const ResultDetailsPage = async ({params}: { params: { id: string }}) => {
+const ResultDetailsPage = async ({params}: { params: Promise<{ id: string }> }) => {
     const {id} = await params;
     const data = await getInterview(id);
 

--- a/app/app/results/page.tsx
+++ b/app/app/results/page.tsx
@@ -28,7 +28,7 @@ async function getInterviews(searchParams: string) {
     }
 }
 
-const ResultsPage = async ({ searchParams }: { searchParams: string }) => {
+const ResultsPage = async ({ searchParams }: { searchParams: Promise<string> }) => {
     const searchParamsValue = await searchParams;
     const data = await getInterviews(searchParamsValue);
 

--- a/app/password/reset/[token]/page.tsx
+++ b/app/password/reset/[token]/page.tsx
@@ -1,7 +1,7 @@
 import ResetPassword from '@/components/auth/ResetPassword'
 import React from 'react'
 
-const ResetPasswordPage = async({params}: {params: {token: string} }) => {
+const ResetPasswordPage = async({params}: {params: Promise<{token: string}> }) => {
   const { token } = await params;
   return (
     <ResetPassword token={token} /> 


### PR DESCRIPTION
- `npm run build` error 
```
   Linting and checking validity of types  ..Failed to compile.

   Linting and checking validity of types  ....next/types/app/api/interviews/[id]/route.ts:49:7
Type error: Type '{ __tag__: "GET"; __param_position__: "second"; __param_type__: { params: { id: string; }; }; }' does not satisfy the constraint 'ParamCheck<RouteContext>'.
  The types of '__param_type__.params' are incompatible between these types.
    Type '{ id: string; }' is missing the following properties from type 'Promise<any>': then, catch, finally, [Symbol.toStringTag]
     |       ^
  50 |         __tag__: 'GET'
  51 |         __param_position__: 'second'
  52 |         __param_type__: SecondArg<MaybeField<TEntry, 'GET'>>
Next.js build worker exited with code: 1 and signal: null
```

- references 
1. https://stackoverflow.com/questions/79370923/next-js-typescript-error-param-type-params-incompatible-with-paramcheckrou
2. https://nextjs.org/docs/app/guides/upgrading/version-15#params--searchparams

- after fixing (adding Promise)

```
   Creating an optimized production build ...
 ✓ Compiled successfully in 14.0s
 ✓ Linting and checking validity of types    
 ✓ Collecting page data    
 ✓ Generating static pages (15/15)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization

Route (app)                                 Size  First Load JS
┌ ○ /                                    9.37 kB         256 kB
├ ○ /_not-found                            990 B         103 kB
├ ƒ /api/auth/[...nextauth]                151 B         102 kB
├ ƒ /api/interviews                        151 B         102 kB
├ ƒ /api/interviews/[id]                   151 B         102 kB
├ ○ /app/dashboard                         151 B         102 kB
├ ƒ /app/interviews                      3.46 kB         249 kB
├ ƒ /app/interviews/conduct/[id]          6.8 kB         175 kB
├ ○ /app/interviews/new                   2.8 kB         215 kB
├ ○ /app/me/update/password              2.03 kB         170 kB
├ ○ /app/me/update/profile               4.71 kB         172 kB
├ ƒ /app/results                         2.25 kB         240 kB
├ ƒ /app/results/[id]                    4.32 kB         255 kB
├ ○ /login                               4.15 kB         172 kB
├ ○ /password/forgot                     1.96 kB         160 kB
├ ƒ /password/reset/[token]              2.15 kB         160 kB
└ ○ /register                            3.93 kB         162 kB
+ First Load JS shared by all             102 kB
  ├ chunks/1684-4d7a96ed42a5678d.js      46.4 kB
  ├ chunks/4bd1b696-8d1c0c5791cd702e.js  53.2 kB
  └ other shared chunks (total)          2.15 kB


ƒ Middleware                             60.2 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

```