### PR TITLE
subscribe frontend form

### DIFF
--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import Subscribe from '@/components/payment/Subscribe'
+import React from 'react'
+
+const SubscribePage = () => {
+    return (
+        <Subscribe />
+    )
+}
+
+export default SubscribePage

--- a/components/payment/Subscribe.tsx
+++ b/components/payment/Subscribe.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React, { use, useEffect, useState } from "react";
+
+import { Button, Input, Radio, RadioGroup } from "@heroui/react";
+import { Logo } from "@/config/Logo";
+import { Icon } from "@iconify/react";
+import { loadStripe } from "@stripe/stripe-js";
+import {
+  CardElement,
+  Elements,
+  useStripe,
+  useElements,
+} from "@stripe/react-stripe-js";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { create } from "domain";
+import { createNewSubscription } from "@/actions/payment.action";
+import { set } from "mongoose";
+import toast from "react-hot-toast";
+
+const stripePromise = loadStripe(
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!
+);
+
+const Subscribe = () => {
+  return (
+    <Elements stripe={stripePromise}>
+      <CheckoutForm />
+    </Elements>
+  );
+};
+
+const CheckoutForm = () => {
+    const  { data } = useSession();
+    const stripe = useStripe();
+    const elements = useElements();
+    const router = useRouter();
+    const [loading, setLoading] = useState<boolean>(false);
+    const [email, setEmail] = useState<string>("");
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (data?.user?.email) {
+            setEmail(data.user.email);
+        }
+    }, [data]);
+
+    useEffect(() => {
+        if(error) {
+            toast.error(error);
+            setError(null);
+        }
+    }, [error]);
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        if (!stripe || !elements) {
+            return;
+        }
+        setLoading(true);
+        setError(null);
+
+        const cardElement = elements.getElement(CardElement);
+        try {
+            if (!cardElement) {
+                throw new Error("Card element not found");
+            }
+
+            const { error: stripeError, paymentMethod } = await stripe.createPaymentMethod({
+                type: 'card',
+                card: cardElement,
+                billing_details: {
+                    email: email,
+                },
+            });
+
+            if (stripeError) {
+                setError(stripeError.message || "An error occurred while processing your payment.");
+                setLoading(false);
+                return;
+            }
+
+            // Call your backend to create a subscription
+            const res = await createNewSubscription(email, paymentMethod.id);
+
+            if (!res) {
+                setError(res.error?.message);
+                setLoading(false);
+                return;
+            }
+
+            if(res?.subscription) {
+                setLoading(false);
+                toast.success("Subscription successful!");
+                router.push("/app/dashboard");
+            }
+        } catch (err) {
+            console.error("Error creating subscription:", err);
+            setError("An error occurred while processing your payment.");
+            setLoading(false);
+        }
+    }
+
+
+    return (
+        <div className="flex h-full w-full items-center justify-center">
+            <div className="flex w-full max-w-sm flex-col gap-4 rounded-large">
+                <div className="flex flex-col items-center pb-6">
+                    <Logo />
+                    <p className="text-xl font-medium">Subscribe</p>
+                    <p className="text-small text-default-500">
+                        Enter your email and card details to subscribe
+                    </p>
+                </div>
+
+                <form onSubmit={handleSubmit}  className="flex flex-col gap-5">
+                    <RadioGroup isDisabled label="Your Plan" defaultValue={"9.99"}>
+                    <Radio value="9.99">$9.99 per month</Radio>
+                    </RadioGroup>
+
+                    <Input
+                        type="email"
+                        label="Email Address"
+                        placeholder="Email"
+                        variant="bordered"
+                        value={email}
+                        isDisabled
+                    />
+                    <div className="my-4">
+                        <CardElement options={{
+                            style: {
+                            base: {
+                                fontSize: '16px',
+                            },
+                            },
+                            hidePostalCode: true,
+                            }} 
+                        />
+                    </div>
+                    <Button
+                        className="w-full"
+                        color="primary"
+                        type="submit"
+                        startContent={<Icon icon="solar:card-send-bold" fontSize={19} />}
+                        isDisabled={!stripe || !elements || loading}
+                    >
+                        {loading ? "Processing..." : "Subscribe"}
+                    </Button>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default Subscribe;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@heroui/theme": "^2.4.15",
         "@iconify/react": "^6.0.0",
         "@react-types/shared": "^3.29.1",
+        "@stripe/react-stripe-js": "^3.7.0",
+        "@stripe/stripe-js": "^7.3.1",
         "autoprefixer": "^10.4.21",
         "bcryptjs": "^3.0.2",
         "cloudinary": "^2.6.1",
@@ -4011,6 +4013,29 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.7.0.tgz",
+      "integrity": "sha512-PYls/2S9l0FF+2n0wHaEJsEU8x7CmBagiH7zYOsxbBlLIHEsqUIQ4MlIAbV9Zg6xwT8jlYdlRIyBTHmO3yM7kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.3.1.tgz",
+      "integrity": "sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@swc/counter": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@heroui/theme": "^2.4.15",
     "@iconify/react": "^6.0.0",
     "@react-types/shared": "^3.29.1",
+    "@stripe/react-stripe-js": "^3.7.0",
+    "@stripe/stripe-js": "^7.3.1",
     "autoprefixer": "^10.4.21",
     "bcryptjs": "^3.0.2",
     "cloudinary": "^2.6.1",


### PR DESCRIPTION
- subscribe page

<img width="749" alt="prep_subscribe_page" src="https://github.com/user-attachments/assets/cfdabb5d-9a73-4985-834e-5d152298631d" />

- Link modal

<img width="478" alt="link_modal" src="https://github.com/user-attachments/assets/4e4bf19a-97c7-42d0-935c-44e253ab7c1f" />

* this Link & its modal 
Browsers try to be helpful by offering autofill for forms that look like they accept payment data. Stripe’s <CardElement /> renders inside an iframe, and the browser recognizes it as a credit card input, triggering autofill behavior.
It looks we can not disable autolink 

- after subscription
<img width="726" alt="after_subscribe_stripe" src="https://github.com/user-attachments/assets/ab2595dd-69a8-43c8-9c4e-22b2658e800d" />

