### PR TITLE
fix build error in invoice page

### DIFF
--- a/app/app/invoices/page.tsx
+++ b/app/app/invoices/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import { getAuthHeader } from '@/helpers/auth';
 import ListInvoices from '@/components/invoice/ListInvoices';
 
+export const dynamic = "force-dynamic";
 
 async function getInvoices() {
     try {


### PR DESCRIPTION
- `npm run build`  got this error 
```
Error occurred prerendering page "/app/invoices". Read more: [https://nextjs.org/docs/messages/prerender-error](vscode-file://vscode-app/c:/Users/masad/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Error: Error fetching invoices: Dynamic server usage: Route /app/invoices couldn't be rendered statically because it used cookies.
```

according to GIt Copilot
```
This error happens because Next.js static site generation (SSG) cannot use dynamic server features like [cookies()](vscode-file://vscode-app/c:/Users/masad/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) during build time.
Your page uses [cookies()](vscode-file://vscode-app/c:/Users/masad/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) (from next/headers) to get authentication/session info, which is only available at request time (not at build time).
```

#### solution is to add this on the top of the page
```TypeScript
export const dynamic = "force-dynamic";
```